### PR TITLE
 Add follow up if file/directory does not exist and more

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -63,6 +63,7 @@
   lineinfile:
     path: /etc/sudoers.d/10-installer
     line: '{{ lookup("env", "USER") }} ALL=(ALL) ALL,(xkeysnail) NOPASSWD: {{ xkeysnail_path.stdout }}'
+    create: yes
   become: yes
 
 - name: Create start up script
@@ -71,6 +72,11 @@
     dest: '{{ xkeysnail_config_dir }}/start-xkeysnail.sh'
     mode: a+x
   become: yes
+
+- name: create user autostart directory
+  file:
+    path: ~/.config/autostart
+    state: directory
 
 - name: Register start up script
   template:

--- a/templates/start-xkeysnail.sh
+++ b/templates/start-xkeysnail.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 if [ -x {{ xkeysnail_path.stdout }} ]; then
+    exec >> /tmp/xkaysnail.log 2>&1
     xhost +SI:localuser:xkeysnail
-    sudo -u xkeysnail DISPLAY=:1 {{ xkeysnail_path.stdout }} {{ xkeysnail_config_dir }}/config.py &
+    sudo -u xkeysnail DISPLAY=$DISPLAY {{ xkeysnail_path.stdout }} {{ xkeysnail_config_dir }}/config.py &
 fi

--- a/templates/start-xkeysnail.sh
+++ b/templates/start-xkeysnail.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ -x {{ xkeysnail_path }} ]; then
+if [ -x {{ xkeysnail_path.stdout }} ]; then
     xhost +SI:localuser:xkeysnail
-    sudo -u xkeysnail DISPLAY=:1 {{ xkeysnail_path }} {{ xkeysnail_config_dir }}/config.py &
+    sudo -u xkeysnail DISPLAY=:1 {{ xkeysnail_path.stdout }} {{ xkeysnail_config_dir }}/config.py &
 fi


### PR DESCRIPTION
+ Add follow up if directory does not exist
  + `/etc/sudoers.d/10-installer`
  + `~/.config/autostart`
+ fix var of xkeysnail's path
  + Since `register` is dict, we need to extract `stdout`